### PR TITLE
Use https gravatar_url to prevent mixed content warnings

### DIFF
--- a/lib/WWW/CPANTS/Web/Util/URL.pm
+++ b/lib/WWW/CPANTS/Web/Util/URL.pm
@@ -24,6 +24,7 @@ sub gravatar_url ($pause_id) {
     email => $pause_id.'@cpan.org',
     size => 130,
     default => 'identicon',
+    https => 1,
   );
 }
 


### PR DESCRIPTION
This PR prevents mixed content warnings.
<img width="371" alt="screen shot 2017-05-27 at 14 09 08" src="https://cloud.githubusercontent.com/assets/1589550/26518192/204746cc-42e6-11e7-9c79-8ab2f9882bcd.png">
