### PR TITLE
Remove all search.cpan.org appearances

### DIFF
--- a/lib/WWW/CPANTS/Web/Plugin/Helpers.pm
+++ b/lib/WWW/CPANTS/Web/Plugin/Helpers.pm
@@ -18,7 +18,6 @@ sub register ($self, $app, $conf) {
   $app->helper(kwalitee_score => \&kwalitee_score);
   $app->helper(release_availability => \&release_availability);
   $app->helper(metacpan_url => \&metacpan_url);
-  $app->helper(search_cpan_url => \&search_cpan_url);
   $app->helper(rt_url => \&rt_url);
   $app->helper(gravatar_url => \&gravatar_url);
 }
@@ -57,10 +56,6 @@ sub gravatar_url ($c, $pause_id) {
 
 sub metacpan_url ($c, $dist) {
   WWW::CPANTS::Web::Util::URL::metacpan_url($dist);
-}
-
-sub search_cpan_url ($c, $dist) {
-  WWW::CPANTS::Web::Util::URL::search_cpan_url($dist);
 }
 
 sub rt_url ($c, $dist) {

--- a/lib/WWW/CPANTS/Web/Util/URL.pm
+++ b/lib/WWW/CPANTS/Web/Util/URL.pm
@@ -9,10 +9,6 @@ sub metacpan_url ($dist) {
   URI->new(sprintf 'https://metacpan.org/release/%s/%s', @$dist{qw/author name_version/});
 }
 
-sub search_cpan_url ($dist) {
-  URI->new(sprintf 'http://search.cpan.org/~%s/%s/', lc $dist->{author}, $dist->{name_version});
-}
-
 sub rt_url ($dist) {
   my $uri = URI->new('https://rt.cpan.org/Public/Dist/Display.html');
   $uri->query_param(Name => $dist->{name});

--- a/web/templates/author/_sidebar.html.ep
+++ b/web/templates/author/_sidebar.html.ep
@@ -37,7 +37,6 @@
   <dd>
     <ul class="list-unstyled">
       <li><a href="http://metacpan.org/author/<%= $pause_id %>">metacpan</a></li>
-      <li><a href="http://search.cpan.org/~<%= $pause_id %>/">search.cpan.org</a></li>
       <li><a href="https://rt.cpan.org/Public/Dist/ByMaintainer.html?Name=<%= $pause_id %>">rt.cpan.org</a></li>
       <li><a href="http://www.cpantesters.org/author/<%= substr($pause_id, 0, 1) %>/<%= $pause_id %>.html">cpantesters</a></li>
 % if ($author->{homepage}) {

--- a/web/templates/dist/_sidebar.html.ep
+++ b/web/templates/dist/_sidebar.html.ep
@@ -39,7 +39,6 @@
     <dd>
       <ul class="list-unstyled">
         <li><a href="<%= metacpan_url($distribution) %>">metacpan.org</a></li>
-        <li><a href="<%= search_cpan_url($distribution) %>">search.cpan.org</a></li>
         <li><a href="<%= rt_url($distribution) %>">rt.cpan.org</a></li>
       </ul>
     </dd>


### PR DESCRIPTION
search.cpan.org is redirected to metacpan.org since a few months now. So the search.cpan.org links are just duplicates
of the metacpan.org links