### PR TITLE
show bugtracker url from metadata if exists

### DIFF
--- a/lib/WWW/CPANTS/Web/Plugin/Helpers.pm
+++ b/lib/WWW/CPANTS/Web/Plugin/Helpers.pm
@@ -18,7 +18,7 @@ sub register ($self, $app, $conf) {
   $app->helper(kwalitee_score => \&kwalitee_score);
   $app->helper(release_availability => \&release_availability);
   $app->helper(metacpan_url => \&metacpan_url);
-  $app->helper(rt_url => \&rt_url);
+  $app->helper(tracker_url => \&tracker_url);
   $app->helper(gravatar_url => \&gravatar_url);
 }
 
@@ -58,8 +58,15 @@ sub metacpan_url ($c, $dist) {
   WWW::CPANTS::Web::Util::URL::metacpan_url($dist);
 }
 
-sub rt_url ($c, $dist) {
-  WWW::CPANTS::Web::Util::URL::rt_url($dist);
+sub tracker_url ($c, $dist) {
+  my $db   = WWW::CPANTS->context->db;
+  my $data = $db->table('Analysis')->select_json_by_uid($dist->{uid}) // '{}';
+  my $json = WWW::CPANTS::Util::JSON::decode_json( $data );
+
+  my $url = $json->{meta_yml}->{resources}->{bugtracker} //
+    WWW::CPANTS::Web::Util::URL::rt_url($dist);
+
+  return $url;
 }
 
 1;

--- a/web/templates/dist/_sidebar.html.ep
+++ b/web/templates/dist/_sidebar.html.ep
@@ -39,7 +39,7 @@
     <dd>
       <ul class="list-unstyled">
         <li><a href="<%= metacpan_url($distribution) %>">metacpan.org</a></li>
-        <li><a href="<%= rt_url($distribution) %>">rt.cpan.org</a></li>
+        <li><a href="<%= tracker_url($distribution) %>">Bugtracker</a></li>
       </ul>
     </dd>
 


### PR DESCRIPTION
Some developers use GitHub issues or other bugtrackers instead of rt.cpan.org. So that url should be
used instead of the standard rt.cpan.org link.