### PR TITLE
ignore extlib/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /etc/config.pl
 /web/bower/
 blib/
+extlib/
 tmp/
 Makefile
 !Makefile.PL


### PR DESCRIPTION
If someone wants to develop something for cpants, one has to clone two modules into extlib/. To avoid
that those modules are added to this repo by accident, the extlib/ dir should be ignored