### PR TITLE
Dist Badges always show a score of 100.00

### DIFF
--- a/lib/WWW/CPANTS/Web/Controller/Dist.pm
+++ b/lib/WWW/CPANTS/Web/Controller/Dist.pm
@@ -21,7 +21,7 @@ sub index ($c) {
     return $c->render(json => $data->{data});
   }
   if ($format eq 'png') {
-    my $path = WWW::CPANTS::Web::Util::Badge->new(100)->path;
+    my $path = WWW::CPANTS::Web::Util::Badge->new($data->{data}{distribution}{core_kwalitee})->path;
     return $c->reply->static($path);
   }
   $c->stash(cpants => $data);


### PR DESCRIPTION
At the moment, all dist badges show a score of 100. For example, <https://cpants.cpanauthors.org/dist/Pod-Perldocs> currently shows "Core Kwalitee 96.77", but the badge currently shows 100.00: ![kwalitee](https://cpants.cpanauthors.org/dist/Pod-Perldocs.png)

I'm having some trouble getting a dev environment set up locally, so I *hope* I got the data hashref right!