### PR TITLE
Add JSON::XS to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -76,6 +76,8 @@ requires 'WWW::Form::UrlEncoded::XS';
 requires 'XML::Atom::SimpleFeed';
 requires 'XML::LibXML';
 requires 'version', '0.73';
+requires 'JSON::XS';
+#requires 'Module::CPANTS::SiteKwalitee'; # https://github.com/cpants/Module-CPANTS-SiteKwalitee
 suggests 'Plack::Middleware::ServerStatus::Lite';
 suggests 'Starman';
 


### PR DESCRIPTION
A clean install on my machine showed that `JSON::XS` is missing from the `cpanfile`.
This commit also adds a mention of `Module::CPANTS::SiteKwalitee`, which currently needs to be installed manually (cpants/Module-CPANTS-SiteKwalitee#3).