### PR TITLE
Added SVG badges

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ requires 'Class::Accessor', '0.19';
 requires 'Class::Load::XS';
 requires 'Const::Fast';
 requires 'Cookie::Baker::XS';
+requires 'Badge::Simple';
 requires 'Data::Binary';
 requires 'DBD::SQLite';
 requires 'DBI';

--- a/lib/WWW/CPANTS/Web/Controller/Author.pm
+++ b/lib/WWW/CPANTS/Web/Controller/Author.pm
@@ -17,6 +17,10 @@ sub index ($c) {
     my $path = WWW::CPANTS::Web::Util::Badge->new($data->{data}{author}{average_core_kwalitee})->path;
     return $c->reply->static($path);
   }
+  if ($format eq 'svg') {
+    my $path = WWW::CPANTS::Web::Util::BadgeSVG->new($data->{data}{author}{average_core_kwalitee})->path;
+    return $c->reply->static($path);
+  }
 
   $c->stash(cpants => $data);
   $c->stash(body_class => "pause-".(lc $id));

--- a/lib/WWW/CPANTS/Web/Controller/Dist.pm
+++ b/lib/WWW/CPANTS/Web/Controller/Dist.pm
@@ -10,7 +10,7 @@ sub index ($c) {
   my $name = $c->param('name');
 
   my $format = '';
-  if ($name =~ s/\.(json|png)$//) {
+  if ($name =~ s/\.(json|png|svg)$//) {
     $format = $1;
     $c->param(name => $name);
     $c->stash(format => $format);
@@ -22,6 +22,10 @@ sub index ($c) {
   }
   if ($format eq 'png') {
     my $path = WWW::CPANTS::Web::Util::Badge->new($data->{data}{distribution}{core_kwalitee})->path;
+    return $c->reply->static($path);
+  }
+  if ($format eq 'svg') {
+    my $path = WWW::CPANTS::Web::Util::BadgeSVG->new($data->{data}{distribution}{core_kwalitee})->path;
     return $c->reply->static($path);
   }
   $c->stash(cpants => $data);

--- a/lib/WWW/CPANTS/Web/Util/BadgeSVG.pm
+++ b/lib/WWW/CPANTS/Web/Util/BadgeSVG.pm
@@ -1,0 +1,27 @@
+package WWW::CPANTS::Web::Util::BadgeSVG;
+
+use WWW::CPANTS;
+use WWW::CPANTS::Util;
+use Badge::Simple;
+
+sub new ($class, $score) {
+  $score = sprintf '%.2f', $score if $score =~ /^[0-9.]+$/;
+  my $file = app_dir('web/public/img/badge/')->child("$score.svg");
+  if (!-f $file) {
+    $file->parent->mkpath;
+    my $color = $score >= 100 ? 'brightgreen' :
+                $score >=  99 ? 'green'       :
+                $score >=  90 ? 'yellowgreen' :
+                $score >=  80 ? 'yellow'      :
+                                'red'         ;
+    Badge::Simple::badge( left=>'kwalitee', right=>$score, color=>$color )
+      ->toFile("$file");
+  }
+  bless {file => $file}, $class;
+}
+
+sub path ($self) {
+  $self->{file}->relative(app_dir('web/public'));
+}
+
+1;


### PR DESCRIPTION
I recently released [`Badge::Simple`](https://metacpan.org/pod/Badge::Simple) ([haukex/Badge-Simple](https://github.com/haukex/Badge-Simple#badge-simple)). If you like this module, here is a patch that adds `WWW::CPANTS::Web::Util::BadgeSVG` (modeled after `WWW::CPANTS::Web::Util::Badge`) to provide SVG badges.
